### PR TITLE
ENG-3652: Check for duplicate element IDs

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -19,7 +19,7 @@ jakartaXMLBindVersion = "4.0.0"
 slf4jVersion = "2.0.7"
 testngVersion = "7.8.0"
 
-project(group: "io.fusionauth", name: "fusionauth-samlv2", version: "1.1.2", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "fusionauth-samlv2", version: "1.1.3", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       cache()

--- a/src/main/java/io/fusionauth/samlv2/service/DefaultSAMLv2Service.java
+++ b/src/main/java/io/fusionauth/samlv2/service/DefaultSAMLv2Service.java
@@ -693,8 +693,12 @@ public class DefaultSAMLv2Service implements SAMLv2Service {
           // Unmarshall the Document into AssertionType.
           jaxbAssertion = unmarshallFromDocument(assertionDoc, AssertionType.class);
 
-          if (!allElementIds.add(((AssertionType) jaxbAssertion).getID())) {
-            throw new SAMLException("Unable to parse SAML v2.0 XML. The document contains duplicate element IDs.");
+          // Ensure decrypted element IDs were not already present elsewhere in the document
+          Set<String> decryptedElementIds = checkDuplicateIDs(assertionDoc.getDocumentElement());
+          for (String decryptedElementId : decryptedElementIds) {
+            if (!allElementIds.add(decryptedElementId)) {
+              throw new SAMLException("Unable to parse SAML v2.0 XML. The document contains duplicate element IDs.");
+            }
           }
 
           // Verify the signature if requested. Add the verified element Ids to the set for the full Response.


### PR DESCRIPTION
Be defensive in checking for duplicate element IDs inside decrypted assertions.