### PR TITLE
Make the NameIDFormat on the metadata a freeform string

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -19,7 +19,7 @@ jakartaXMLBindVersion = "4.0.0"
 slf4jVersion = "2.0.7"
 testngVersion = "7.8.0"
 
-project(group: "io.fusionauth", name: "fusionauth-samlv2", version: "1.1.3", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "fusionauth-samlv2", version: "1.1.4", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       cache()

--- a/build.savant
+++ b/build.savant
@@ -19,7 +19,7 @@ jakartaXMLBindVersion = "4.0.0"
 slf4jVersion = "2.0.7"
 testngVersion = "7.8.0"
 
-project(group: "io.fusionauth", name: "fusionauth-samlv2", version: "1.1.4", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "fusionauth-samlv2", version: "2.0.0", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       cache()

--- a/src/main/java/io/fusionauth/samlv2/domain/MetaData.java
+++ b/src/main/java/io/fusionauth/samlv2/domain/MetaData.java
@@ -49,7 +49,7 @@ public class MetaData {
 
     public List<Certificate> certificates = new ArrayList<>();
 
-    public NameIDFormat nameIDFormat;
+    public String nameIDFormat;
 
     public boolean wantAssertionsSigned;
   }

--- a/src/main/java/io/fusionauth/samlv2/service/DefaultSAMLv2Service.java
+++ b/src/main/java/io/fusionauth/samlv2/service/DefaultSAMLv2Service.java
@@ -433,7 +433,7 @@ public class DefaultSAMLv2Service implements SAMLv2Service {
       }
 
       if (metaData.sp.nameIDFormat != null) {
-        sp.getNameIDFormat().add(metaData.sp.nameIDFormat.toSAMLFormat());
+        sp.getNameIDFormat().add(metaData.sp.nameIDFormat);
       }
 
       // Add certificates
@@ -609,7 +609,7 @@ public class DefaultSAMLv2Service implements SAMLv2Service {
       metaData.sp = new SPMetaData();
       metaData.sp.acsEndpoint = !sp.getAssertionConsumerService().isEmpty() ? sp.getAssertionConsumerService().get(0).getLocation() : null;
       try {
-        metaData.sp.nameIDFormat = !sp.getNameIDFormat().isEmpty() ? NameIDFormat.fromSAMLFormat(sp.getNameIDFormat().get(0)) : null;
+        metaData.sp.nameIDFormat = !sp.getNameIDFormat().isEmpty() ? sp.getNameIDFormat().get(0) : null;
       } catch (Exception e) {
         // fromSAMLFormat may throw an exception if the Name ID Format is not defined by our NameIDFormat enum.
         throw new SAMLException(e.getCause());

--- a/src/test/java/io/fusionauth/samlv2/service/DefaultSAMLv2ServiceTest.java
+++ b/src/test/java/io/fusionauth/samlv2/service/DefaultSAMLv2ServiceTest.java
@@ -583,7 +583,7 @@ public class DefaultSAMLv2ServiceTest {
     metaData.entityId = "https://fusionauth.io/samlv2/sp/" + metaData.id;
     metaData.sp = new SPMetaData();
     metaData.sp.acsEndpoint = "https://fusionauth.io/oauth2/callback";
-    metaData.sp.nameIDFormat = NameIDFormat.EmailAddress;
+    metaData.sp.nameIDFormat = NameIDFormat.EmailAddress.toSAMLFormat();
 
     DefaultSAMLv2Service service = new DefaultSAMLv2Service();
     String xml = service.buildMetadataResponse(metaData);
@@ -591,7 +591,7 @@ public class DefaultSAMLv2ServiceTest {
     assertTrue(xml.contains("_" + metaData.id));
     assertTrue(xml.contains(metaData.entityId));
     assertTrue(xml.contains(metaData.sp.acsEndpoint));
-    assertTrue(xml.contains(metaData.sp.nameIDFormat.toSAMLFormat()));
+    assertTrue(xml.contains(metaData.sp.nameIDFormat));
     assertTrue(xml.contains("<ns2:SPSSODescriptor AuthnRequestsSigned=\"false\" WantAssertionsSigned=\"false\" protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\">"));
 
     // Now parse it


### PR DESCRIPTION
In section 8.3 of the saml-core-2.0 spec this field is optional and can be any valid URI